### PR TITLE
Listen to 'form changed' events and add isValid property to MontonioCheckout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Invokes an approving review from repo owner teams to merge PRs
-*                       @montonio/cto
+*                       @montonio/cto @montonio/software-engineer-payments
 
 # Restricted files cannot be edited without approval from the Infrastructure team
-/.github/**/cicd.yml    @montonio/cto
-/.github/CODEOWNERS     @montonio/cto
+/.github/**/cicd.yml    @montonio/infrastructure
+/.github/CODEOWNERS     @montonio/infrastructure

--- a/src/common/exceptions/exceptions.ts
+++ b/src/common/exceptions/exceptions.ts
@@ -19,8 +19,8 @@ export class PaymentAuthNotInitializedError extends Error {
 }
 
 export class ValidationError extends Error {
-    constructor() {
-        super('Validation failed');
+    constructor(message: string = 'Validation failed. Check payment details and try again.') {
+        super(message);
         this.name = 'ValidationError';
     }
 }

--- a/src/components/BaseComponent.ts
+++ b/src/components/BaseComponent.ts
@@ -2,11 +2,11 @@ import { Iframe } from './';
 import { ConfigService, HTTPService, MessagingService } from '../services';
 
 export abstract class BaseComponent {
+    public loaded: boolean = false;
     protected httpService: HTTPService;
     protected configService: ConfigService;
     protected messagingService: MessagingService;
     protected mountElement: HTMLElement | null = null;
-    protected loaded: boolean = false;
     private _iframe: Iframe | null = null;
 
     protected constructor() {

--- a/src/components/Iframe/Iframe.ts
+++ b/src/components/Iframe/Iframe.ts
@@ -35,7 +35,7 @@ export class Iframe {
 
     public unmount(): void {
         // This only clears the resize subscription because that's the only subscription
-        // on the MessagingService instance created in this Iframe instance
+        // on the MessagingService created in this Iframe instance
         if (this.element.contentWindow) {
             this.messagingService.clearAllSubscriptions();
         }

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -14,6 +14,8 @@ import { MessageByType, MessageTypeEnum } from '../../services/Messaging';
 import { MontonioCheckoutNotInitializedError, PaymentFailedError, ValidationError } from '../../common';
 
 export class MontonioCheckout extends BaseComponent {
+    public isValid: boolean = false;
+
     private options: CheckoutOptions;
     private readonly environment: EnvironmentOptions;
     private paymentAuth: PaymentAuth | null = null;
@@ -43,6 +45,8 @@ export class MontonioCheckout extends BaseComponent {
             this.iframe.mount();
 
             await this.messagingService.waitForMessage(MessageTypeEnum.CHECKOUT_PAYMENT_COMPONENT_READY, this.iframe);
+
+            this.listenForPaymentFormChanges();
 
             this.loaded = true;
 
@@ -201,6 +205,20 @@ export class MontonioCheckout extends BaseComponent {
     }
 
     /**
+     * Listen for changes in the payment form and update the isValid property
+     */
+    private listenForPaymentFormChanges(): void {
+        this.messagingService.subscribe(
+            MessageTypeEnum.CHECKOUT_PAYMENT_FORM_CHANGED,
+            (message) => {
+                this.isValid = message.payload.isValid;
+                console.log('CHECKOUT_PAYMENT_FORM_CHANGED', this.isValid);
+            },
+            this.iframe,
+        );
+    }
+
+    /**
      * After a payment has completed, fetch the return URL. Keep fetching until we
      * exhaust all the attempts
      */
@@ -236,7 +254,7 @@ export class MontonioCheckout extends BaseComponent {
     }
 
     private cleanupAfterPaymentSubmission(): void {
-        this.messagingService.clearAllSubscriptions();
+        this.messagingService.clearSubscriptionsExcept([MessageTypeEnum.CHECKOUT_PAYMENT_FORM_CHANGED]);
 
         this.cleanupPaymentAuth();
     }

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -113,7 +113,7 @@ export class MessagingService {
      * Clear all subscriptions except the ones in the except array
      */
     public clearSubscriptionsExcept(except: MessageTypeEnum[]): void {
-        for (const key of this.subscriptions.keys()) {
+        for (const key of [...this.subscriptions.keys()]) {
             if (!except.includes(key)) {
                 this.subscriptions.delete(key);
             }

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -110,6 +110,17 @@ export class MessagingService {
     }
 
     /**
+     * Clear all subscriptions except the ones in the except array
+     */
+    public clearSubscriptionsExcept(except: MessageTypeEnum[]): void {
+        for (const key of this.subscriptions.keys()) {
+            if (!except.includes(key)) {
+                this.subscriptions.delete(key);
+            }
+        }
+    }
+
+    /**
      * Remove subscription for an iframe
      */
     private removeIframeFromSubscription(messageType: MessageTypeEnum, iframe: Iframe): void {

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -23,6 +23,7 @@ export enum MessageTypeEnum {
     CHECKOUT_HEIGHT_CHANGED = 'montonio:checkout.heightChanged',
     CHECKOUT_VALIDATE_FIELDS = 'montonio:checkout.validateFields',
     CHECKOUT_VALIDATE_FIELDS_RESULT = 'montonio:checkout.validateFieldsResult',
+    CHECKOUT_PAYMENT_FORM_CHANGED = 'montonio:checkout.paymentFormChanged',
 }
 
 export type Messages =
@@ -84,6 +85,12 @@ export type Messages =
       }
     | {
           name: MessageTypeEnum.CHECKOUT_VALIDATE_FIELDS_RESULT;
+          payload: {
+              isValid: boolean;
+          };
+      }
+    | {
+          name: MessageTypeEnum.CHECKOUT_PAYMENT_FORM_CHANGED;
           payload: {
               isValid: boolean;
           };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
         "noImplicitThis": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
-        "noImplicitReturns": true
+        "noImplicitReturns": true,
+        "stripInternal": true
     },
     "include": [
         "src/**/*",

--- a/tsconfig.live.json
+++ b/tsconfig.live.json
@@ -1,6 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "stripInternal": true
-    }
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,7 @@ import { readFileSync } from 'fs';
 
 const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
-export default defineConfig(({ mode }) => {
-    const tsconfigPath = mode === 'live' ? './tsconfig.live.json' : './tsconfig.json';
-
+export default defineConfig(() => {
     return {
         build: {
             target: 'ES2018',
@@ -21,7 +19,7 @@ export default defineConfig(({ mode }) => {
             sourcemap: true,
             rollupOptions: {
                 plugins: [
-                    typescript({ tsconfig: tsconfigPath }),
+                    typescript(),
                     replace({
                         __MONTONIO_JS_VERSION__: JSON.stringify(packageJson.version),
                         preventAssignment: true,


### PR DESCRIPTION
## Description and Jira ticket

For environments that cannot use the asynchronous `validateOrReject()` method, we can provide the `isValid` parameter on `MontonioCheckout`. This helps our WooCommerce plugin to validate the form more easily like this:

`if (montonioCheckout.isValid === true)`

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How to verify/test:
1. 

## Checklist
-   [ ] I have verified that my code works according to the ticket description
-   [ ] I have added the necessary tests
-   [ ] I have commented/documented my code where necessary
-   [ ] I have performed a self-review of my own code
