### PR TITLE
Prevent document scrolling during payment auth

### DIFF
--- a/src/components/PaymentAuth/PaymentAuth.ts
+++ b/src/components/PaymentAuth/PaymentAuth.ts
@@ -2,7 +2,7 @@ import { PaymentAuthOptions } from './types';
 import { Iframe } from '../Iframe/Iframe';
 import { BaseComponent } from '../BaseComponent';
 import { MessageTypeEnum, PaymentAuthMessageData } from '../../services/Messaging';
-import { setBodyOverflowHidden, restoreBodyOverflow } from '../../utils';
+import { disableBodyScroll, restoreBodyOverflow } from '../../utils';
 
 export class PaymentAuth extends BaseComponent {
     private options: PaymentAuthOptions;
@@ -30,7 +30,8 @@ export class PaymentAuth extends BaseComponent {
             }
 
             // Set body overflow hidden to prevent background scrolling during Payment Auth
-            this.originalBodyOverflow = setBodyOverflowHidden();
+            const { originalOverflow } = disableBodyScroll();
+            this.originalBodyOverflow = originalOverflow;
 
             // Create iframe for embedded payment auth
             this.iframe = new Iframe({

--- a/src/components/PaymentAuth/PaymentAuth.ts
+++ b/src/components/PaymentAuth/PaymentAuth.ts
@@ -2,9 +2,11 @@ import { PaymentAuthOptions } from './types';
 import { Iframe } from '../Iframe/Iframe';
 import { BaseComponent } from '../BaseComponent';
 import { MessageTypeEnum, PaymentAuthMessageData } from '../../services/Messaging';
+import { setBodyOverflowHidden, restoreBodyOverflow } from '../../utils';
 
 export class PaymentAuth extends BaseComponent {
     private options: PaymentAuthOptions;
+    private originalBodyOverflow: string | null = null;
 
     constructor(options: PaymentAuthOptions) {
         super();
@@ -16,43 +18,69 @@ export class PaymentAuth extends BaseComponent {
      * Initialize and mount the payment auth iframe
      */
     public async initialize(): Promise<void> {
-        // Handle redirect-based payment auth first
-        if (this.options.paymentAuthData.type === 'redirect') {
-            await this.redirectViaPost(this.options.paymentAuthData);
-            return;
+        try {
+            // Handle redirect-based payment auth first
+            if (this.options.paymentAuthData.type === 'redirect') {
+                await this.redirectViaPost(this.options.paymentAuthData);
+                return;
+            }
+
+            if (!this.options.paymentAuthData.embeddedUrl) {
+                throw new Error('Embedded URL is not set in paymentAuthData');
+            }
+
+            // Set body overflow hidden to prevent background scrolling during Payment Auth
+            this.originalBodyOverflow = setBodyOverflowHidden();
+
+            // Create iframe for embedded payment auth
+            this.iframe = new Iframe({
+                src: this.options.paymentAuthData.embeddedUrl,
+                mountElement: this.mountElement!,
+                styles: {
+                    width: '100vw',
+                    height: '100vh',
+                    position: 'fixed',
+                    top: '0',
+                    left: '0',
+                    zIndex: '16777271',
+                },
+                resizeOnHeightChange: false,
+            });
+
+            this.iframe.mount();
+
+            // Wait for the payment auth component to be ready
+            await this.messagingService.waitForMessage(
+                MessageTypeEnum.CHECKOUT_PAYMENT_AUTH_COMPONENT_READY,
+                this.iframe,
+            );
+
+            // Submit payment auth data to the payment auth iframe
+            this.messagingService.postMessage(this.iframe, {
+                name: MessageTypeEnum.CHECKOUT_SEND_PAYMENT_AUTH_DATA,
+                payload: {
+                    paymentAuthData: this.options.paymentAuthData,
+                },
+            });
+
+            this.loaded = true;
+        } catch (error) {
+            this.cleanup();
+            throw error;
+        }
+    }
+
+    /**
+     * Clean up the payment auth component and restore body overflow
+     */
+    public cleanup(): void {
+        if (this.loaded) {
+            // Restore the original body overflow
+            restoreBodyOverflow(this.originalBodyOverflow);
         }
 
-        if (!this.options.paymentAuthData.embeddedUrl) {
-            throw new Error('Embedded URL is not set in paymentAuthData');
-        }
-
-        // Create iframe for embedded payment auth
-        this.iframe = new Iframe({
-            src: this.options.paymentAuthData.embeddedUrl,
-            mountElement: this.mountElement!,
-            styles: {
-                width: '100vw',
-                height: '100vh',
-                position: 'fixed',
-                top: '0',
-                left: '0',
-                zIndex: '16777271',
-            },
-            resizeOnHeightChange: false,
-        });
-
-        this.iframe.mount();
-
-        // Wait for the payment auth component to be ready
-        await this.messagingService.waitForMessage(MessageTypeEnum.CHECKOUT_PAYMENT_AUTH_COMPONENT_READY, this.iframe);
-
-        // Submit payment auth data to the payment auth iframe
-        this.messagingService.postMessage(this.iframe, {
-            name: MessageTypeEnum.CHECKOUT_SEND_PAYMENT_AUTH_DATA,
-            payload: {
-                paymentAuthData: this.options.paymentAuthData,
-            },
-        });
+        // Call parent method to handle iframe cleanup
+        super.cleanup();
     }
 
     /**

--- a/src/components/PaymentAuth/PaymentAuth.ts
+++ b/src/components/PaymentAuth/PaymentAuth.ts
@@ -37,12 +37,12 @@ export class PaymentAuth extends BaseComponent {
                 src: this.options.paymentAuthData.embeddedUrl,
                 mountElement: this.mountElement!,
                 styles: {
-                    width: '100vw',
-                    height: '100vh',
+                    width: '100dvw',
+                    height: '100dvh',
                     position: 'fixed',
                     top: '0',
                     left: '0',
-                    zIndex: '16777271',
+                    zIndex: '2147483647',
                 },
                 resizeOnHeightChange: false,
             });

--- a/src/utils/DOM/DOM.ts
+++ b/src/utils/DOM/DOM.ts
@@ -19,3 +19,24 @@ export function getElement(selector: string | HTMLElement): HTMLElement {
 
     return selector;
 }
+
+/**
+ * Set 'overflow: hidden' on the document body and return the original value which can be used to restore it later
+ */
+export function setBodyOverflowHidden(): string | null {
+    const originalOverflow = document.body.style.overflow || null;
+    document.body.style.overflow = 'hidden';
+    return originalOverflow;
+}
+
+/**
+ * Restore the body overflow to its original value
+ */
+export function restoreBodyOverflow(originalOverflow: string | null = null): void {
+    if (originalOverflow) {
+        document.body.style.overflow = originalOverflow;
+    } else {
+        // Remove the style attribute if it was empty originally
+        document.body.style.removeProperty('overflow');
+    }
+}

--- a/src/utils/DOM/DOM.ts
+++ b/src/utils/DOM/DOM.ts
@@ -22,17 +22,18 @@ export function getElement(selector: string | HTMLElement): HTMLElement {
 
 /**
  * Set 'overflow: hidden' on the document body and return the original value which can be used to restore it later
+ * @returns object with the original overflow value
  */
-export function setBodyOverflowHidden(): string | null {
+export function disableBodyScroll(): { originalOverflow: string | null } {
     const originalOverflow = document.body.style.overflow || null;
     document.body.style.overflow = 'hidden';
-    return originalOverflow;
+    return { originalOverflow };
 }
 
 /**
  * Restore the body overflow to its original value
  */
-export function restoreBodyOverflow(originalOverflow: string | null = null): void {
+export function restoreBodyOverflow(originalOverflow: string | null): void {
     if (originalOverflow) {
         document.body.style.overflow = originalOverflow;
     } else {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export { getElement, setBodyOverflowHidden, restoreBodyOverflow } from './DOM/DOM';
+export { getElement, disableBodyScroll, restoreBodyOverflow } from './DOM/DOM';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export { getElement } from './DOM/DOM';
+export { getElement, setBodyOverflowHidden, restoreBodyOverflow } from './DOM/DOM';


### PR DESCRIPTION
## Description and Jira ticket

- When we render the modal for payment auth (e.g. 3DS for cards), we don't want the rest of the page to be scrollable. This PR disables scrolling by setting the body overflow to hidden and restores the original value on cleanup.
- The SDK user can still override this using !important rules if they don't like this behavior

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How to verify/test:
1. 

## Checklist
-   [ ] I have verified that my code works according to the ticket description
-   [ ] I have added the necessary tests
-   [ ] I have commented/documented my code where necessary
-   [ ] I have performed a self-review of my own code
