### PR TITLE
tell the sdk user if the error is already displayed in the form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.0.49",
+    "version": "1.0.50",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@montonio/montonio-js",
-            "version": "1.0.49",
+            "version": "1.0.50",
             "devDependencies": {
                 "@eslint/js": "^9.26.0",
                 "@rollup/plugin-replace": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.0.49",
+    "version": "1.0.50",
     "description": "Montonio JS SDK for front-end web applications",
     "type": "module",
     "publishConfig": {

--- a/src/common/exceptions/exceptions.ts
+++ b/src/common/exceptions/exceptions.ts
@@ -17,6 +17,8 @@ export class MontonioCheckoutNotInitializedError extends Error {
 }
 
 export class ValidationError extends Error {
+    displayedInPaymentComponent: boolean = true;
+
     constructor(message: string = 'Validation failed. Check payment details and try again.') {
         super(message);
         this.name = ErrorEnum.VALIDATION_ERROR;
@@ -25,6 +27,7 @@ export class ValidationError extends Error {
 
 export class PaymentFailedError extends Error {
     paymentFailedMessageData: PaymentFailedMessageData;
+    displayedInPaymentComponent: boolean = true;
 
     constructor(paymentFailedMessageData: PaymentFailedMessageData) {
         super(`Payment failed: ${paymentFailedMessageData.errorCode}`);


### PR DESCRIPTION
## Description and Jira ticket

- This is for WooCommerce to know if it should display the error to the user or not. Helps avoid unnecessary page reloads in classic checkouts.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How to verify/test:
1. 

## Checklist
-   [ ] I have verified that my code works according to the ticket description
-   [ ] I have added the necessary tests
-   [ ] I have commented/documented my code where necessary
-   [ ] I have performed a self-review of my own code
