### PR TITLE
feat: PAYM-1300: add on action required message to signal 3ds start

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ const checkoutOptions = {
         // Unlock your checkout form to allow the user to try again
     },
     onActionRequired: (payload) => {
-        // Optional. Called when additional user action is required (e.g. authentication)
-        // payload.type is the type of action (e.g. 'AUTHENTICATION').
+        // Optional. Called when additional user action is required (e.g. 3DS, OTP).
+        // Use it to lock the pay button or show an overlay. When payload.action is
+        // 'scrollIntoView', scroll or focus the payment area so the user can complete
+        // authentication there.
     },
 };
 
@@ -122,6 +124,6 @@ When the payment completes (successfully or with an error), the appropriate call
 
 - **`onSuccess(result)`**: Called when payment is successful. The result contains `paymentStatus`, `orderToken`, and `returnUrl` fields.
 - **`onError(error)`**: Called when payment fails or validation errors occur.
-- **`onActionRequired(payload)`** (Optional): Called when additional user action is required (e.g. authentication such as 3DS or OTP). Use it to lock the Pay button or show an overlay. The `payload` has `type` (e.g. `'AUTHENTICATION'`).
+- **`onActionRequired(payload)`** (Optional): Called when additional user action is required (e.g. authentication such as 3DS or OTP). Use it to lock the pay button or show an overlay. The `payload` has `action` (e.g. `'scrollIntoView'`); when it is `'scrollIntoView'`, scroll or focus the payment area so the user can complete authentication there.
 
 The `returnUrl` is the URL you provided in the backend request to create the order. As per the API documentation, this URL will contain the `order-token` query parameter, which you can use to validate the payment. In most cases, you should redirect the user to the `returnUrl` in your `onSuccess` callback and handle the token validation on that page.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const checkoutOptions = {
     },
     onActionRequired: (payload) => {
         // Optional. Called when additional user action is required (e.g. authentication)
-        // payload.type is the kind of action (e.g. 'authentication').
+        // payload.type is the kind of action (e.g. 'AUTHENTICATION').
     },
 };
 
@@ -122,6 +122,6 @@ When the payment completes (successfully or with an error), the appropriate call
 
 - **`onSuccess(result)`**: Called when payment is successful. The result contains `paymentStatus`, `orderToken`, and `returnUrl` fields.
 - **`onError(error)`**: Called when payment fails or validation errors occur.
-- **`onActionRequired(payload)`** (Optional): Called when additional user action is required (e.g. authentication such as 3DS or OTP). Use it to lock the Pay button or show an overlay. The `payload` has `type` (e.g. `'authentication'`).
+- **`onActionRequired(payload)`** (Optional): Called when additional user action is required (e.g. authentication such as 3DS or OTP). Use it to lock the Pay button or show an overlay. The `payload` has `type` (e.g. `'AUTHENTICATION'`).
 
 The `returnUrl` is the URL you provided in the backend request to create the order. As per the API documentation, this URL will contain the `order-token` query parameter, which you can use to validate the payment. In most cases, you should redirect the user to the `returnUrl` in your `onSuccess` callback and handle the token validation on that page.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const checkoutOptions = {
     },
     onActionRequired: (payload) => {
         // Optional. Called when additional user action is required (e.g. authentication)
-        // payload.type is the kind of action (e.g. 'AUTHENTICATION').
+        // payload.type is the type of action (e.g. 'AUTHENTICATION').
     },
 };
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ We support installation both as a JavaScript module (ESM) and as an embedded scr
 ## ES Module
 
 1. Install the package using npm or yarn:
+
 ```bash
 npm install @montonio/montonio-js
 ```
+
 2. Import the library in your JavaScript code:
+
 ```javascript
 import { MontonioCheckout } from '@montonio/montonio-js';
 ```
@@ -55,9 +58,9 @@ import { MontonioCheckout } from '@montonio/montonio-js'; // ES Module usage. Se
 const checkoutOptions = {
     sessionUuid: 'session-uuid', // The UUID of the session created on your server
     environment: 'sandbox', // Defaults to 'production'
-    locale: 'en',   // The language of the payment gateway. Defaults to your store default language. 
-                    // Available values are ('en', 'et', 'lt', 'lv', 'pl', 'ru', 'fi')
-                    // TypeScript users can use LocaleEnum.EN (or ET, LT, etc.) by importing LocaleEnum from @montonio/montonio-js
+    locale: 'en', // The language of the payment gateway. Defaults to your store default language.
+    // Available values are ('en', 'et', 'lt', 'lv', 'pl', 'ru', 'fi')
+    // TypeScript users can use LocaleEnum.EN (or ET, LT, etc.) by importing LocaleEnum from @montonio/montonio-js
     onSuccess: (result) => {
         // Payment completed successfully
         // Redirect to the thank you page
@@ -67,7 +70,11 @@ const checkoutOptions = {
         // Payment failed or validation error occurred
         console.error('Payment failed:', error);
         // Unlock your checkout form to allow the user to try again
-    }
+    },
+    onActionRequired: (payload) => {
+        // Optional. Called when additional user action is required (e.g. authentication)
+        // payload.type is the kind of action (e.g. 'authentication').
+    },
 };
 
 const montonioCheckout = new MontonioCheckout(checkoutOptions);
@@ -97,7 +104,7 @@ Once the user has clicked the "Pay" button in your checkout and you have validat
 
 Make sure you **include the session UUID in the order request**. See the [Order data structure](https://docs.montonio.com/api/stargate/guides/orders#1-order-data-structure) section of the Orders guide for more details.
 
-Once the order is created, you can call the `submitPayment` method on the `MontonioCheckout` instance. 
+Once the order is created, you can call the `submitPayment` method on the `MontonioCheckout` instance.
 
 Immediately after the user clicks "Pay" and even before you create the Montonio order, lock your checkout and prevent the user from making any further changes. Show a loading indicator to the user while the order is being created and while the payment is being submitted.
 
@@ -109,10 +116,12 @@ montonioCheckout.submitPayment();
 // The onError callback will be invoked if payment fails
 ```
 
-The `MontonioCheckout.submitPayment()` method will initiate the payment submission. In case a payment method requires additional user authentication (such as 3DS for card payments), a modal will pop up to handle the authentication. 
+The `MontonioCheckout.submitPayment()` method will initiate the payment submission. In case a payment method requires additional user authentication (such as 3DS for card payments), a modal will pop up to handle the authentication.
 
 When the payment completes (successfully or with an error), the appropriate callback you defined during initialization will be invoked:
+
 - **`onSuccess(result)`**: Called when payment is successful. The result contains `paymentStatus`, `orderToken`, and `returnUrl` fields.
 - **`onError(error)`**: Called when payment fails or validation errors occur.
+- **`onActionRequired(payload)`** (Optional): Called when additional user action is required (e.g. authentication such as 3DS or OTP). Use it to lock the Pay button or show an overlay. The `payload` has `type` (e.g. `'authentication'`).
 
 The `returnUrl` is the URL you provided in the backend request to create the order. As per the API documentation, this URL will contain the `order-token` query parameter, which you can use to validate the payment. In most cases, you should redirect the user to the `returnUrl` in your `onSuccess` callback and handle the token validation on that page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Montonio JS SDK for front-end web applications",
     "type": "module",
     "publishConfig": {

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -168,11 +168,9 @@ export class MontonioCheckout extends BaseComponent {
      */
     private setUpActionRequiredListener(): void {
         this.messagingService.subscribe(
-            MessageTypeEnum.CHECKOUT_ON_ACTION_REQUIRED,
+            MessageTypeEnum.CHECKOUT_ACTION_REQUIRED,
             (message) => {
-                this.handleActionRequired({
-                    type: message.payload.type,
-                });
+                this.handleActionRequired(message.payload);
             },
             this.iframe,
         );

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -168,7 +168,7 @@ export class MontonioCheckout extends BaseComponent {
      */
     private setUpActionRequiredListener(): void {
         this.messagingService.subscribe(
-            MessageTypeEnum.ON_ACTION_REQUIRED,
+            MessageTypeEnum.CHECKOUT_ON_ACTION_REQUIRED,
             (message) => {
                 this.handleActionRequired({
                     type: message.payload.type,

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -1,4 +1,5 @@
 import {
+    ActionRequiredPayload,
     CheckoutOptions,
     GatewayUrlResponse,
     PaymentResult,
@@ -147,6 +148,7 @@ export class MontonioCheckout extends BaseComponent {
         this.setUpPaymentCompletedListener();
         this.setUpPaymentFailedListener();
         this.setUpValidationListener();
+        this.setUpActionRequiredListener();
         this.setUpPaymentAuthListener();
         this.setUpRedirectListener();
     }
@@ -156,6 +158,21 @@ export class MontonioCheckout extends BaseComponent {
             MessageTypeEnum.CHECKOUT_REDIRECT,
             (message) => {
                 window.location.href = message.payload.redirectUrl;
+            },
+            this.iframe,
+        );
+    }
+
+    /**
+     * Listen for action required (e.g. 3DS started)
+     */
+    private setUpActionRequiredListener(): void {
+        this.messagingService.subscribe(
+            MessageTypeEnum.ON_ACTION_REQUIRED,
+            (message) => {
+                this.handleActionRequired({
+                    type: message.payload.type,
+                });
             },
             this.iframe,
         );
@@ -344,5 +361,13 @@ export class MontonioCheckout extends BaseComponent {
     private handlePaymentError(error: Error): void {
         this.options.onError(error);
         console.error('MONTONIO-JS: handlePaymentError: onError callback called with error:', error);
+    }
+
+    /**
+     * Handle action required - calls the optional onActionRequired callback
+     */
+    private handleActionRequired(payload: ActionRequiredPayload): void {
+        this.options.onActionRequired?.(payload);
+        console.log('MONTONIO-JS: handleActionRequired: onActionRequired callback called with payload:', payload);
     }
 }

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -365,7 +365,9 @@ export class MontonioCheckout extends BaseComponent {
      * Handle action required - calls the optional onActionRequired callback
      */
     private handleActionRequired(payload: ActionRequiredPayload): void {
-        this.options.onActionRequired?.(payload);
-        console.log('MONTONIO-JS: handleActionRequired: onActionRequired callback called with payload:', payload);
+        if (this.options.onActionRequired) {
+            this.options.onActionRequired(payload);
+            console.log('MONTONIO-JS: handleActionRequired: onActionRequired callback called with payload:', payload);
+        }
     }
 }

--- a/src/components/MontonioCheckout/types.ts
+++ b/src/components/MontonioCheckout/types.ts
@@ -29,9 +29,24 @@ export interface CheckoutOptions {
      * Called when a payment fails or validation errors occur
      */
     onError: (error: Error) => void;
+
+    /**
+     * (Optional)
+     * Called when the payment requires additional user action (e.g. 3DS, redirect)
+     */
+    onActionRequired?: (payload: ActionRequiredPayload) => void;
 }
 
 export type UpdatableCheckoutOptions = Pick<Partial<CheckoutOptions>, 'locale'>;
+
+export type ActionRequiredType = 'authentication';
+
+/**
+ * Kind of action: e.g. 'authentication' (3DS, OTP, etc.). Use to lock pay button or show overlay.
+ */
+export interface ActionRequiredPayload {
+    type: ActionRequiredType;
+}
 
 /**
  * Checkout session data returned from Stargate

--- a/src/components/MontonioCheckout/types.ts
+++ b/src/components/MontonioCheckout/types.ts
@@ -40,14 +40,14 @@ export interface CheckoutOptions {
 export type UpdatableCheckoutOptions = Pick<Partial<CheckoutOptions>, 'locale'>;
 
 /**
- * Kind of action required: e.g. authentication (3DS, OTP, etc.). Use to lock pay button or show overlay.
+ * Type of action required: e.g. authentication (3DS, OTP, etc.). Use to lock pay button or show overlay.
  */
-export enum ActionRequiredEnum {
-    Authentication = 'authentication',
+export enum ActionRequiredTypeEnum {
+    AUTHENTICATION = 'AUTHENTICATION',
 }
 
 export interface ActionRequiredPayload {
-    type: ActionRequiredEnum;
+    type: ActionRequiredTypeEnum;
 }
 
 /**

--- a/src/components/MontonioCheckout/types.ts
+++ b/src/components/MontonioCheckout/types.ts
@@ -43,7 +43,7 @@ export type UpdatableCheckoutOptions = Pick<Partial<CheckoutOptions>, 'locale'>;
  * Type of action required: e.g. authentication (3DS, OTP, etc.). Use to lock pay button or show overlay.
  */
 export enum ActionRequiredTypeEnum {
-    AUTHENTICATION = 'AUTHENTICATION',
+    AUTHENTICATION = 'authentication',
 }
 
 export interface ActionRequiredPayload {

--- a/src/components/MontonioCheckout/types.ts
+++ b/src/components/MontonioCheckout/types.ts
@@ -39,15 +39,15 @@ export interface CheckoutOptions {
 
 export type UpdatableCheckoutOptions = Pick<Partial<CheckoutOptions>, 'locale'>;
 
-/**
- * Type of action required: e.g. authentication (3DS, OTP, etc.). Use to lock pay button or show overlay.
- */
-export enum ActionRequiredTypeEnum {
-    AUTHENTICATION = 'authentication',
+export enum ActionRequiredActionEnum {
+    /*
+     * Scroll the payment area into view so the user can complete authentication there
+     */
+    SCROLL_INTO_VIEW = 'scrollIntoView',
 }
 
 export interface ActionRequiredPayload {
-    type: ActionRequiredTypeEnum;
+    action: ActionRequiredActionEnum;
 }
 
 /**

--- a/src/components/MontonioCheckout/types.ts
+++ b/src/components/MontonioCheckout/types.ts
@@ -39,13 +39,15 @@ export interface CheckoutOptions {
 
 export type UpdatableCheckoutOptions = Pick<Partial<CheckoutOptions>, 'locale'>;
 
-export type ActionRequiredType = 'authentication';
-
 /**
- * Kind of action: e.g. 'authentication' (3DS, OTP, etc.). Use to lock pay button or show overlay.
+ * Kind of action required: e.g. authentication (3DS, OTP, etc.). Use to lock pay button or show overlay.
  */
+export enum ActionRequiredEnum {
+    Authentication = 'authentication',
+}
+
 export interface ActionRequiredPayload {
-    type: ActionRequiredType;
+    type: ActionRequiredEnum;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { ErrorEnum } from './common';
 import { MontonioCheckout } from './components';
 import type { ActionRequiredPayload, CheckoutOptions } from './components/MontonioCheckout/types';
-import { ActionRequiredTypeEnum, LocaleEnum } from './components/MontonioCheckout/types';
+import { ActionRequiredActionEnum, LocaleEnum } from './components/MontonioCheckout/types';
 import { Environment } from './services/Config/types';
 import { MessageTypeEnum } from './services/Messaging';
 
 export {
     ActionRequiredPayload,
-    ActionRequiredTypeEnum,
+    ActionRequiredActionEnum,
     CheckoutOptions,
     MontonioCheckout,
     Environment,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,17 @@
 import { ErrorEnum } from './common';
 import { MontonioCheckout } from './components';
-import type { CheckoutOptions } from './components/MontonioCheckout/types';
+import type { ActionRequiredPayload, ActionRequiredType, CheckoutOptions } from './components/MontonioCheckout/types';
 import { LocaleEnum } from './components/MontonioCheckout/types';
 import { Environment } from './services/Config/types';
 import { MessageTypeEnum } from './services/Messaging';
 
-export { CheckoutOptions, MontonioCheckout, Environment, MessageTypeEnum, LocaleEnum, ErrorEnum };
+export {
+    ActionRequiredPayload,
+    ActionRequiredType,
+    CheckoutOptions,
+    MontonioCheckout,
+    Environment,
+    MessageTypeEnum,
+    LocaleEnum,
+    ErrorEnum,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { ErrorEnum } from './common';
 import { MontonioCheckout } from './components';
 import type { ActionRequiredPayload, CheckoutOptions } from './components/MontonioCheckout/types';
-import { ActionRequiredEnum, LocaleEnum } from './components/MontonioCheckout/types';
+import { ActionRequiredTypeEnum, LocaleEnum } from './components/MontonioCheckout/types';
 import { Environment } from './services/Config/types';
 import { MessageTypeEnum } from './services/Messaging';
 
 export {
     ActionRequiredPayload,
-    ActionRequiredEnum,
+    ActionRequiredTypeEnum,
     CheckoutOptions,
     MontonioCheckout,
     Environment,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { ErrorEnum } from './common';
 import { MontonioCheckout } from './components';
-import type { ActionRequiredPayload, ActionRequiredType, CheckoutOptions } from './components/MontonioCheckout/types';
-import { LocaleEnum } from './components/MontonioCheckout/types';
+import type { ActionRequiredPayload, CheckoutOptions } from './components/MontonioCheckout/types';
+import { ActionRequiredEnum, LocaleEnum } from './components/MontonioCheckout/types';
 import { Environment } from './services/Config/types';
 import { MessageTypeEnum } from './services/Messaging';
 
 export {
     ActionRequiredPayload,
-    ActionRequiredType,
+    ActionRequiredEnum,
     CheckoutOptions,
     MontonioCheckout,
     Environment,

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -1,4 +1,4 @@
-import { ActionRequiredEnum, LocaleEnum } from '../../components/MontonioCheckout/types';
+import { ActionRequiredTypeEnum, LocaleEnum } from '../../components/MontonioCheckout/types';
 
 export interface MessageSubscription {
     handler: (message: Messages) => void;
@@ -25,7 +25,7 @@ export enum MessageTypeEnum {
     CHECKOUT_VALIDATE_FIELDS_RESULT = 'montonio:checkout.validateFieldsResult',
     CHECKOUT_PAYMENT_FORM_CHANGED = 'montonio:checkout.paymentFormChanged',
     CHECKOUT_REDIRECT = 'montonio:checkout.redirect',
-    CHECKOUT_ON_ACTION_REQUIRED = 'montonio:checkout.actionRequired',
+    CHECKOUT_ACTION_REQUIRED = 'montonio:checkout.actionRequired',
 }
 
 export type Messages =
@@ -104,9 +104,9 @@ export type Messages =
           };
       }
     | {
-          name: MessageTypeEnum.CHECKOUT_ON_ACTION_REQUIRED;
+          name: MessageTypeEnum.CHECKOUT_ACTION_REQUIRED;
           payload: {
-              type: ActionRequiredEnum;
+              type: ActionRequiredTypeEnum;
           };
       };
 

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -1,4 +1,4 @@
-import { ActionRequiredTypeEnum, LocaleEnum } from '../../components/MontonioCheckout/types';
+import { ActionRequiredActionEnum, LocaleEnum } from '../../components/MontonioCheckout/types';
 
 export interface MessageSubscription {
     handler: (message: Messages) => void;
@@ -106,7 +106,7 @@ export type Messages =
     | {
           name: MessageTypeEnum.CHECKOUT_ACTION_REQUIRED;
           payload: {
-              type: ActionRequiredTypeEnum;
+              action: ActionRequiredActionEnum;
           };
       };
 

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -1,4 +1,4 @@
-import { ActionRequiredType, LocaleEnum } from '../../components/MontonioCheckout/types';
+import { ActionRequiredEnum, LocaleEnum } from '../../components/MontonioCheckout/types';
 
 export interface MessageSubscription {
     handler: (message: Messages) => void;
@@ -106,7 +106,7 @@ export type Messages =
     | {
           name: MessageTypeEnum.CHECKOUT_ON_ACTION_REQUIRED;
           payload: {
-              type: ActionRequiredType;
+              type: ActionRequiredEnum;
           };
       };
 

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -1,4 +1,4 @@
-import { LocaleEnum } from '../../components/MontonioCheckout/types';
+import { ActionRequiredType, LocaleEnum } from '../../components/MontonioCheckout/types';
 
 export interface MessageSubscription {
     handler: (message: Messages) => void;
@@ -25,6 +25,7 @@ export enum MessageTypeEnum {
     CHECKOUT_VALIDATE_FIELDS_RESULT = 'montonio:checkout.validateFieldsResult',
     CHECKOUT_PAYMENT_FORM_CHANGED = 'montonio:checkout.paymentFormChanged',
     CHECKOUT_REDIRECT = 'montonio:checkout.redirect',
+    ON_ACTION_REQUIRED = 'montonio:checkout.actionRequired',
 }
 
 export type Messages =
@@ -100,6 +101,12 @@ export type Messages =
           name: MessageTypeEnum.CHECKOUT_REDIRECT;
           payload: {
               redirectUrl: string;
+          };
+      }
+    | {
+          name: MessageTypeEnum.ON_ACTION_REQUIRED;
+          payload: {
+              type: ActionRequiredType;
           };
       };
 

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -25,7 +25,7 @@ export enum MessageTypeEnum {
     CHECKOUT_VALIDATE_FIELDS_RESULT = 'montonio:checkout.validateFieldsResult',
     CHECKOUT_PAYMENT_FORM_CHANGED = 'montonio:checkout.paymentFormChanged',
     CHECKOUT_REDIRECT = 'montonio:checkout.redirect',
-    ON_ACTION_REQUIRED = 'montonio:checkout.actionRequired',
+    CHECKOUT_ON_ACTION_REQUIRED = 'montonio:checkout.actionRequired',
 }
 
 export type Messages =
@@ -104,7 +104,7 @@ export type Messages =
           };
       }
     | {
-          name: MessageTypeEnum.ON_ACTION_REQUIRED;
+          name: MessageTypeEnum.CHECKOUT_ON_ACTION_REQUIRED;
           payload: {
               type: ActionRequiredType;
           };


### PR DESCRIPTION
## Reason, description, and testing instructions for the change

**Reason and description of the change** _(link to Jira ticket or provide reason and description here directly)_

- Currently, when a merchant uses the embedded checkout, the page is unaware of the 3DS verification so they can't lock their forms.

**Specific testing steps for this PR (if applicable):**

- Create a new order
- Make sure to use the demo card with 3DS
- add a console.log into the onActionRequired
- It gets fired
- works

_Refer to our [testing guidelines](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%F0%9F%A7%AA-Testing-your-changes) for general instructions on testing the change and verifying it doesn't introduce security issues._

## Rollback procedure
_Refer to our [rollback guide](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%99%BB%EF%B8%8F-Rolling-back-changes-(procedures-to-address-failures)) for rolling back the change in case of failure._

## Checklist

- [x] I have performed a self-review of my own code, tested the change manually, and verified the security impact.
- [x] I have followed Montonio's [Software Development and Release Process](https://montonio.atlassian.net/wiki/x/FYAU0w), [Secure Coding Guidelines](https://montonio.atlassian.net/wiki/x/GAAa0w), and [Configuration Standards](https://montonio.atlassian.net/wiki/x/BIAb0w).

**Security impact**
  - [ ] High
  - [ ] Medium
  - [x] Low

**Significant change**

Is this a Significant Change in the context of [our definition of a Significant Change](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%8F%AB-Significant-changes)?
- [ ] Yes
- [x] No