### PR TITLE
fix: lazily resolve iframe contentWindow to prevent mount errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@montonio/montonio-js",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "license": "MIT",
             "dependencies": {
                 "@datadog/browser-logs": "6.22.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Montonio JS SDK for front-end web applications",
     "type": "module",
     "publishConfig": {

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -19,11 +19,11 @@ export class MessagingService {
     }
 
     /**
-     * Subscribe to messages of a specific type from a specific source iframe
-     * @param messageType The message type to listen for
-     * @param handler Handler function to call when the message is received
-     * @param iframe Iframe object to listen to
-     * @returns Subscription ID that can be used to unsubscribe
+     * Subscribe to messages of a specific type from a specific source iframe.
+     * @param messageType The message type to listen for.
+     * @param handler Handler function to call when the message is received.
+     * @param iframe Iframe object to listen to.
+     * @returns Subscription ID that can be used to unsubscribe.
      */
     public subscribe<T extends MessageTypeEnum>(
         messageType: T,

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -158,7 +158,11 @@ export class MessagingService {
                     const sourceMatches = subscription.sources.some((source) => {
                         try {
                             return source.getContentWindow() === event.source;
-                        } catch {
+                        } catch (error) {
+                            console.error(
+                                'MONTONIO-JS: MessagingService: Failed to resolve contentWindow for source:',
+                                error,
+                            );
                             return false;
                         }
                     });

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -93,7 +93,7 @@ export class MessagingService {
      * Post a message to a specific iframe window
      */
     public postMessage(iframe: Iframe, messageData: Messages, targetOrigin: string = '*'): void {
-        const target = this.extractWindowFromIframe(iframe);
+        const target = iframe.getContentWindow();
         target.postMessage(messageData, targetOrigin);
     }
 
@@ -181,12 +181,5 @@ export class MessagingService {
                 console.error('Error processing iframe message:', error);
             }
         });
-    }
-
-    /**
-     * Extract the window source from the Iframe object
-     */
-    private extractWindowFromIframe(iframe: Iframe): Window {
-        return iframe.getContentWindow();
     }
 }

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -34,12 +34,9 @@ export class MessagingService {
             throw new Error(`Subscription for '${messageType}' already exists`);
         }
 
-        // Convert Iframe object to Window object
-        const windowSource = this.extractWindowFromIframe(iframe);
-
         this.subscriptions.set(messageType, {
             handler: handler as (message: Messages) => void,
-            sources: [windowSource],
+            sources: [iframe],
         });
     }
 
@@ -52,10 +49,8 @@ export class MessagingService {
             throw new Error(`Subscription for '${messageType}' not found`);
         }
 
-        const windowSource = this.extractWindowFromIframe(iframe);
-
-        if (!subscription.sources.includes(windowSource)) {
-            subscription.sources.push(windowSource);
+        if (!subscription.sources.includes(iframe)) {
+            subscription.sources.push(iframe);
         }
     }
 
@@ -129,9 +124,7 @@ export class MessagingService {
             throw new Error(`Subscription for '${messageType}' not found`);
         }
 
-        const windowSource = this.extractWindowFromIframe(iframe);
-
-        subscription.sources = subscription.sources.filter((source) => source !== windowSource);
+        subscription.sources = subscription.sources.filter((source) => source !== iframe);
 
         // Delete the subscription if it has no sources left
         if (subscription.sources.length === 0) {
@@ -159,8 +152,16 @@ export class MessagingService {
                         return;
                     }
 
-                    // Check if the event source matches any of the specified sources
-                    const sourceMatches = subscription.sources.some((source) => source === event.source);
+                    // Check if the event source matches any of the specified sources.
+                    // contentWindow is resolved lazily here — the iframe must be loaded
+                    // to have sent a message, so getContentWindow() is safe at this point.
+                    const sourceMatches = subscription.sources.some((source) => {
+                        try {
+                            return source.getContentWindow() === event.source;
+                        } catch {
+                            return false;
+                        }
+                    });
                     if (!sourceMatches) {
                         return;
                     }

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -1,8 +1,9 @@
 import { ActionRequiredActionEnum, LocaleEnum } from '../../components/MontonioCheckout/types';
+import type { Iframe } from '../../components/Iframe/Iframe';
 
 export interface MessageSubscription {
     handler: (message: Messages) => void;
-    sources: Window[];
+    sources: Iframe[];
 }
 
 export interface MessageOptions {


### PR DESCRIPTION
## Reason, description, and testing instructions for the change

**Reason and description of the change**

- `MessagingService.subscribe()` was calling `iframe.getContentWindow()` eagerly at subscription time. When `Iframe.mount()` called `startResizing()` synchronously right after `appendChild()`, the iframe's `contentWindow` was not yet available in certain environments — causing the error `Iframe contentWindow is not available. Make sure the iframe is mounted and loaded.` (94 occurrences observed in the past month).
- Root cause: `contentWindow` can be `null` immediately after `appendChild()` if the mount element is not yet connected to the document (e.g. a framework renders the container element after calling `initialize()`), or due to browser-specific timing quirks.
- Fix: `MessagingService` now stores `Iframe` objects in subscriptions instead of resolving them to `Window` objects eagerly. The `contentWindow` is resolved lazily inside `setupMessageListener()` when an actual message arrives — at which point the iframe is guaranteed to be loaded (it just sent a message). A `try/catch` around the lazy resolution ensures graceful handling of any edge cases.

**Specific testing steps for this PR (if applicable):**

- Reproduce by passing a detached `HTMLElement` (not yet appended to `document.body`) as the `mountTo` argument to `initialize()` — previously this threw immediately, now it proceeds correctly once the element is connected
- Verify normal checkout flow still works end-to-end: mount, form interaction, resize, payment submission, 3DS auth

## Rollback procedure
_Refer to our [rollback guide](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%99%BB%EF%B8%8F-Rolling-back-changes-(procedures-to-address-failures)) for rolling back the change in case of failure._

## Checklist

- [x] I have performed a self-review of my own code, tested the change manually, and verified the security impact.
- [x] I have followed Montonio's [Software Development and Release Process](https://montonio.atlassian.net/wiki/x/FYAU0w), [Secure Coding Guidelines](https://montonio.atlassian.net/wiki/x/GAAa0w), and [Configuration Standards](https://montonio.atlassian.net/wiki/x/BIAb0w).

**Security impact**
  - [ ] High
  - [ ] Medium
  - [x] Low

**Significant change**

Is this a Significant Change in the context of [our definition of a Significant Change](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%8F%AB-Significant-changes)?
- [ ] Yes
- [x] No