### PR TITLE
Improve logging consistency and error reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@montonio/montonio-js",
-            "version": "1.1.7",
+            "version": "1.1.8",
             "license": "MIT",
             "dependencies": {
                 "@datadog/browser-logs": "6.22.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "description": "Montonio JS SDK for front-end web applications",
     "type": "module",
     "publishConfig": {

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -35,7 +35,7 @@ export class MontonioCheckout extends BaseComponent {
 
         LoggingService.instance.initialize(this.environment, this.options.sessionUuid);
 
-        this.logger.info('Checkout created', options);
+        this.logger.info('Checkout created', { options });
 
         validateCheckoutOptions(options);
     }
@@ -65,7 +65,7 @@ export class MontonioCheckout extends BaseComponent {
             this.logger.info(`Successfully mounted checkout to [${mountTo}]`);
             return true;
         } catch (error) {
-            this.logger.error(`Error mounting checkout to [${mountTo}]`, { error });
+            this.logger.error(`Error mounting checkout to [${mountTo}], ${error}`);
             this.cleanup();
             throw error;
         }
@@ -76,7 +76,7 @@ export class MontonioCheckout extends BaseComponent {
      * @param options - Updatable options
      */
     public updateOptions(options: UpdatableCheckoutOptions): void {
-        this.logger.info('Updating checkout options', options);
+        this.logger.info('Updating checkout options', { options });
         if (!this.loaded) {
             throw new MontonioCheckoutNotInitializedError();
         }
@@ -196,7 +196,7 @@ export class MontonioCheckout extends BaseComponent {
         this.messagingService.subscribe(
             MessageTypeEnum.CHECKOUT_PAYMENT_COMPLETED,
             async (completedMessage) => {
-                this.logger.info('Checkout payment completed', completedMessage);
+                this.logger.info('Checkout payment completed', { event: completedMessage });
 
                 this.cleanupPaymentAuth();
 
@@ -242,7 +242,7 @@ export class MontonioCheckout extends BaseComponent {
         this.messagingService.subscribe(
             MessageTypeEnum.CHECKOUT_VALIDATE_FIELDS_RESULT,
             (res) => {
-                this.logger.info('Checkout validate fields result', res);
+                this.logger.info('Checkout validate fields result', { event: res });
                 if (!res.payload.isValid) {
                     this.handlePaymentError(new ValidationError());
                 }
@@ -259,7 +259,7 @@ export class MontonioCheckout extends BaseComponent {
             MessageTypeEnum.CHECKOUT_START_PAYMENT_AUTH,
             async (message) => {
                 try {
-                    this.logger.info('Payment auth started', message);
+                    this.logger.info('Payment auth started', { event: message });
 
                     this.paymentAuth = new PaymentAuth({
                         paymentAuthData: message.payload.paymentAuthData,
@@ -312,7 +312,7 @@ export class MontonioCheckout extends BaseComponent {
                     };
                 }
             } catch (error) {
-                this.logger.error(`Error fetching return URL from [${url}]`, { error });
+                this.logger.error(`Error fetching return URL from [${url}], ${error}`);
             }
 
             // Wait for 1 second before the next attempt
@@ -350,7 +350,7 @@ export class MontonioCheckout extends BaseComponent {
      */
     private handlePaymentSuccess(result: PaymentResult): void {
         this.options.onSuccess(result);
-        this.logger.info('Triggered onSuccess callback', result);
+        this.logger.info('Triggered onSuccess callback', { params: result });
     }
 
     /**
@@ -358,7 +358,7 @@ export class MontonioCheckout extends BaseComponent {
      */
     private handlePaymentError(error: Error): void {
         this.options.onError(error);
-        this.logger.warn('Triggered onError callback', { error });
+        this.logger.info('Triggered onError callback', { error });
     }
 
     /**
@@ -367,7 +367,7 @@ export class MontonioCheckout extends BaseComponent {
     private handleActionRequired(payload: ActionRequiredPayload): void {
         if (this.options.onActionRequired) {
             this.options.onActionRequired(payload);
-            this.logger.info('Triggered onActionRequired callback', payload);
+            this.logger.info('Triggered onActionRequired callback', { params: payload });
         }
     }
 }

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -65,7 +65,7 @@ export class MontonioCheckout extends BaseComponent {
             this.logger.info(`Successfully mounted checkout to [${mountTo}]`);
             return true;
         } catch (error) {
-            this.logger.error(`Error mounting checkout to [${mountTo}], ${error}`);
+            this.logger.error(`Error mounting checkout to [${mountTo}], ${error}`, error);
             this.cleanup();
             throw error;
         }
@@ -312,7 +312,7 @@ export class MontonioCheckout extends BaseComponent {
                     };
                 }
             } catch (error) {
-                this.logger.error(`Error fetching return URL from [${url}], ${error}`);
+                this.logger.error(`Error fetching return URL from [${url}], ${error}`, error);
             }
 
             // Wait for 1 second before the next attempt

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -65,7 +65,7 @@ export class MontonioCheckout extends BaseComponent {
             this.logger.info(`Successfully mounted checkout to [${mountTo}]`);
             return true;
         } catch (error) {
-            this.logger.error(`Error mounting checkout to [${mountTo}], ${error}`, error);
+            this.logger.error(`Error mounting checkout to [${mountTo}]`, error);
             this.cleanup();
             throw error;
         }
@@ -312,7 +312,7 @@ export class MontonioCheckout extends BaseComponent {
                     };
                 }
             } catch (error) {
-                this.logger.error(`Error fetching return URL from [${url}], ${error}`, error);
+                this.logger.error(`Error fetching return URL from [${url}]`, error);
             }
 
             // Wait for 1 second before the next attempt

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -35,7 +35,7 @@ export class MontonioCheckout extends BaseComponent {
 
         LoggingService.instance.initialize(this.environment, this.options.sessionUuid);
 
-        this.logger.info('Checkout created', { options });
+        this.logger.info('New checkout instance created', { options });
 
         validateCheckoutOptions(options);
     }

--- a/src/services/Logging/Logging.ts
+++ b/src/services/Logging/Logging.ts
@@ -13,17 +13,17 @@ export class MontonioLogger {
     constructor(private readonly context: string) {}
 
     info(message: string, data?: object): void {
-        console.log(`${this.logPrefix}, ${this.context}: ${message}`, ...(data ? [data] : []));
+        console.log(`${this.logPrefix} - ${this.context}: ${message}`, ...(data ? [data] : []));
         datadogLogs.logger.info(message, { context: this.context, ...data });
     }
 
     warn(message: string, data?: object): void {
-        console.warn(`${this.logPrefix}, ${this.context}: ${message}`, ...(data ? [data] : []));
+        console.warn(`${this.logPrefix} - ${this.context}: ${message}`, ...(data ? [data] : []));
         datadogLogs.logger.warn(message, { context: this.context, ...data });
     }
 
     error(message: string, data?: object): void {
-        console.error(`${this.logPrefix}, ${this.context}: ${message}`, ...(data ? [data] : []));
+        console.error(`${this.logPrefix} - ${this.context}: ${message}`, ...(data ? [data] : []));
         datadogLogs.logger.error(message, { context: this.context, ...data });
     }
 }
@@ -61,7 +61,7 @@ export class LoggingService {
                 datadogLogs.setGlobalContextProperty('sessionUuid', sessionUuid);
                 this.logger.info(`Updated sessionUuid to [${sessionUuid}]`, { sessionUuid });
             } catch (error) {
-                this.logger.error(`Error updating sessionUuid to [${sessionUuid}]`, { error });
+                this.logger.error(`Error updating sessionUuid to [${sessionUuid}], ${error}`);
             }
             return;
         }

--- a/src/services/Logging/Logging.ts
+++ b/src/services/Logging/Logging.ts
@@ -65,7 +65,7 @@ export class LoggingService {
                 datadogLogs.setGlobalContextProperty('sessionUuid', sessionUuid);
                 this.logger.info(`Updated sessionUuid to [${sessionUuid}]`, { sessionUuid });
             } catch (error) {
-                this.logger.error(`Error updating sessionUuid to [${sessionUuid}], ${error}`, error);
+                this.logger.error(`Error updating sessionUuid to [${sessionUuid}]`, error);
             }
             return;
         }

--- a/src/services/Logging/Logging.ts
+++ b/src/services/Logging/Logging.ts
@@ -22,9 +22,13 @@ export class MontonioLogger {
         datadogLogs.logger.warn(message, { context: this.context, ...data });
     }
 
-    error(message: string, data?: object): void {
-        console.error(`${this.logPrefix} - ${this.context}: ${message}`, ...(data ? [data] : []));
-        datadogLogs.logger.error(message, { context: this.context, ...data });
+    error(message: string, error: unknown, data?: object): void {
+        console.error(`${this.logPrefix} - ${this.context}: ${message}`, error);
+        datadogLogs.logger.error(
+            message,
+            { context: this.context, ...data },
+            error instanceof Error ? error : undefined,
+        );
     }
 }
 
@@ -61,7 +65,7 @@ export class LoggingService {
                 datadogLogs.setGlobalContextProperty('sessionUuid', sessionUuid);
                 this.logger.info(`Updated sessionUuid to [${sessionUuid}]`, { sessionUuid });
             } catch (error) {
-                this.logger.error(`Error updating sessionUuid to [${sessionUuid}], ${error}`);
+                this.logger.error(`Error updating sessionUuid to [${sessionUuid}], ${error}`, error);
             }
             return;
         }

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -161,7 +161,7 @@ export class MessagingService {
                         try {
                             return source.getContentWindow() === event.source;
                         } catch (error) {
-                            this.logger.error('Failed to resolve contentWindow for source', { error });
+                            this.logger.error(`Failed to resolve contentWindow for source, ${error}`, { event });
                             return false;
                         }
                     });
@@ -173,11 +173,11 @@ export class MessagingService {
                     try {
                         subscription.handler(message);
                     } catch (error) {
-                        this.logger.error('Error in message handler', { error });
+                        this.logger.error(`Error in message handler, ${error}`);
                     }
                 });
             } catch (error) {
-                this.logger.error('Error processing iframe message', { error });
+                this.logger.error(`Error processing iframe message, ${error}`);
             }
         });
     }

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -161,7 +161,7 @@ export class MessagingService {
                         try {
                             return source.getContentWindow() === event.source;
                         } catch (error) {
-                            this.logger.error(`Failed to resolve contentWindow for source, ${error}`, { event });
+                            this.logger.error(`Failed to resolve contentWindow for source, ${error}`, error, { event });
                             return false;
                         }
                     });
@@ -173,11 +173,11 @@ export class MessagingService {
                     try {
                         subscription.handler(message);
                     } catch (error) {
-                        this.logger.error(`Error in message handler, ${error}`);
+                        this.logger.error(`Error in message handler, ${error}`, error);
                     }
                 });
             } catch (error) {
-                this.logger.error(`Error processing iframe message, ${error}`);
+                this.logger.error(`Error processing iframe message, ${error}`, error);
             }
         });
     }

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -161,7 +161,7 @@ export class MessagingService {
                         try {
                             return source.getContentWindow() === event.source;
                         } catch (error) {
-                            this.logger.error(`Failed to resolve contentWindow for source, ${error}`, error, { event });
+                            this.logger.error('Failed to resolve contentWindow for source', error, { event });
                             return false;
                         }
                     });
@@ -173,11 +173,11 @@ export class MessagingService {
                     try {
                         subscription.handler(message);
                     } catch (error) {
-                        this.logger.error(`Error in message handler, ${error}`, error);
+                        this.logger.error('Error in message handler', error);
                     }
                 });
             } catch (error) {
-                this.logger.error(`Error processing iframe message, ${error}`, error);
+                this.logger.error('Error processing iframe message', error);
             }
         });
     }

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -161,7 +161,7 @@ export class MessagingService {
                         try {
                             return source.getContentWindow() === event.source;
                         } catch (error) {
-                            this.logger.error('Failed to resolve contentWindow for source', error, { event });
+                            this.logger.error('Failed to resolve contentWindow object for Iframe', error, { event });
                             return false;
                         }
                     });

--- a/src/services/Messaging/types.ts
+++ b/src/services/Messaging/types.ts
@@ -1,5 +1,5 @@
 import { ActionRequiredActionEnum, LocaleEnum } from '../../components/MontonioCheckout/types';
-import type { Iframe } from '../../components/Iframe/Iframe';
+import type { Iframe } from '../../components';
 
 export interface MessageSubscription {
     handler: (message: Messages) => void;


### PR DESCRIPTION
## Reason, description, and testing instructions for the change

**Reason and description of the change**

- Improved logging consistency across the SDK: log prefix separator changed from `,` to `-` for better readability
- Refactored `MontonioLogger.error()` signature to accept `error: unknown` as a dedicated second argument (instead of bundling it in a `data` object), enabling Datadog to properly receive the `Error` instance for stack traces
- Updated all `logger.error()` call sites in `MontonioCheckout`, `MessagingService`, and `LoggingService` to use the new signature
- Wrapped event/options objects in named keys (e.g. `{ options }`, `{ event }`, `{ params }`) in `logger.info()` calls to improve log structure in Datadog
- Changed `handlePaymentError` log level from `warn` to `info`
- Fixed import path in `Messaging/types.ts` to use the barrel export (`../../components`)
- Bumped SDK version to `1.1.8`

**Specific testing steps for this PR (if applicable):**

- Trigger checkout mount errors and verify Datadog shows proper error stack traces
- Verify log messages in browser console use `-` as separator instead of `,`
- Verify structured fields (options, event, params) appear correctly in Datadog log attributes

_Refer to our [testing guidelines](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%F0%9F%A7%AA-Testing-your-changes) for general instructions on testing the change and verifying it doesn't introduce security issues._

## Rollback procedure
_Refer to our [rollback guide](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%99%BB%EF%B8%8F-Rolling-back-changes-(procedures-to-address-failures)) for rolling back the change in case of failure._

## Checklist

- [x] I have performed a self-review of my own code, tested the change manually, and verified the security impact.
- [x] I have followed Montonio's [Software Development and Release Process](https://montonio.atlassian.net/wiki/x/FYAU0w), [Secure Coding Guidelines](https://montonio.atlassian.net/wiki/x/GAAa0w), and [Configuration Standards](https://montonio.atlassian.net/wiki/x/BIAb0w).

**Security impact**
  - [ ] High
  - [ ] Medium
  - [x] Low

**Significant change**

Is this a Significant Change in the context of [our definition of a Significant Change](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%8F%AB-Significant-changes)?
- [ ] Yes
- [x] No