### PR TITLE
Fix MessagingService listener leak on cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@montonio/montonio-js",
-            "version": "1.1.8",
+            "version": "1.1.9",
             "license": "MIT",
             "dependencies": {
                 "@datadog/browser-logs": "6.22.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@montonio/montonio-js",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "description": "Montonio JS SDK for front-end web applications",
     "type": "module",
     "publishConfig": {

--- a/src/components/BaseComponent.ts
+++ b/src/components/BaseComponent.ts
@@ -30,10 +30,12 @@ export abstract class BaseComponent {
     }
 
     public cleanup(): void {
-        if (this.iframe) {
-            this.iframe.unmount();
-            this.iframe = null;
+        if (this._iframe) {
+            this._iframe.unmount();
+            this._iframe = null;
         }
+        this.messagingService.destroy();
+        this.loaded = false;
     }
 
     public abstract initialize(...args: unknown[]): Promise<unknown>;

--- a/src/components/BaseComponent.ts
+++ b/src/components/BaseComponent.ts
@@ -29,7 +29,7 @@ export abstract class BaseComponent {
         this._iframe = value;
     }
 
-    public cleanup(): void {
+    public destroy(): void {
         if (this._iframe) {
             this._iframe.unmount();
             this._iframe = null;

--- a/src/components/Iframe/Iframe.ts
+++ b/src/components/Iframe/Iframe.ts
@@ -34,11 +34,10 @@ export class Iframe {
     }
 
     public unmount(): void {
-        // This only clears the resize subscription because that's the only subscription
-        // on the MessagingService created in this Iframe instance
-        if (this.element.contentWindow) {
-            this.messagingService.clearAllSubscriptions();
-        }
+        // Tear down the internal MessagingService (used for the height-change
+        // subscription) so its window 'message' listener is removed, not just
+        // its subscriptions cleared.
+        this.messagingService.destroy();
 
         if (this.element.parentNode) {
             this.element.parentNode.removeChild(this.element);

--- a/src/components/MontonioCheckout/MontonioCheckout.ts
+++ b/src/components/MontonioCheckout/MontonioCheckout.ts
@@ -66,7 +66,7 @@ export class MontonioCheckout extends BaseComponent {
             return true;
         } catch (error) {
             this.logger.error(`Error mounting checkout to [${mountTo}]`, error);
-            this.cleanup();
+            this.destroy();
             throw error;
         }
     }
@@ -339,8 +339,7 @@ export class MontonioCheckout extends BaseComponent {
                 this.paymentAuth.iframe,
             );
 
-            // Clean up and destroy the PaymentAuth component
-            this.paymentAuth.cleanup();
+            this.paymentAuth.destroy();
             this.paymentAuth = null;
         }
     }

--- a/src/components/PaymentAuth/PaymentAuth.ts
+++ b/src/components/PaymentAuth/PaymentAuth.ts
@@ -66,22 +66,22 @@ export class PaymentAuth extends BaseComponent {
 
             this.loaded = true;
         } catch (error) {
-            this.cleanup();
+            this.destroy();
             throw error;
         }
     }
 
     /**
-     * Clean up the payment auth component and restore body overflow
+     * Destroy the payment auth component and restore body overflow
      */
-    public cleanup(): void {
+    public destroy(): void {
         if (this.loaded) {
             // Restore the original body overflow
             restoreBodyOverflow(this.originalBodyOverflow);
         }
 
-        // Call parent method to handle iframe cleanup
-        super.cleanup();
+        // Call parent method to tear down the iframe and MessagingService
+        super.destroy();
     }
 
     /**

--- a/src/services/Messaging/Messaging.ts
+++ b/src/services/Messaging/Messaging.ts
@@ -15,9 +15,21 @@ export class MessagingService {
      */
     private readonly logger = new MontonioLogger('MessagingService');
     private subscriptions: Map<MessageTypeEnum, MessageSubscription> = new Map();
+    private readonly messageHandler: (event: MessageEvent) => void;
 
     public constructor() {
-        this.setupMessageListener();
+        this.messageHandler = (event) => this.handleWindowMessage(event);
+        window.addEventListener('message', this.messageHandler);
+    }
+
+    /**
+     * Tear down this MessagingService: clear all subscriptions and remove
+     * the global window message listener. Call this when the owning component
+     * is being disposed to avoid leaking listeners across the page lifetime.
+     */
+    public destroy(): void {
+        this.clearAllSubscriptions();
+        window.removeEventListener('message', this.messageHandler);
     }
 
     /**
@@ -100,24 +112,6 @@ export class MessagingService {
     }
 
     /**
-     * Clear all subscriptions
-     */
-    public clearAllSubscriptions(): void {
-        this.subscriptions.clear();
-    }
-
-    /**
-     * Clear all subscriptions except the ones in the except array
-     */
-    public clearSubscriptionsExcept(except: MessageTypeEnum[]): void {
-        for (const key of [...this.subscriptions.keys()]) {
-            if (!except.includes(key)) {
-                this.subscriptions.delete(key);
-            }
-        }
-    }
-
-    /**
      * Remove an iframe from a subscription's sources
      */
     public removeIframeFromSubscription(messageType: MessageTypeEnum, iframe: Iframe): void {
@@ -135,50 +129,56 @@ export class MessagingService {
     }
 
     /**
-     * Set up the message listener for capturing all window messages
+     * Clear all subscriptions
      */
-    private setupMessageListener(): void {
-        window.addEventListener('message', (event) => {
-            try {
-                // Validate that the message is properly formatted to filter out noise
-                if (!event.data || typeof event.data !== 'object' || !event.data.name) {
+    private clearAllSubscriptions(): void {
+        this.subscriptions.clear();
+    }
+
+    /**
+     * Handle a window 'message' event: route it to any matching subscription
+     * whose source iframe sent it.
+     */
+    private handleWindowMessage(event: MessageEvent): void {
+        try {
+            // Validate that the message is properly formatted to filter out noise
+            if (!event.data || typeof event.data !== 'object' || !event.data.name) {
+                return;
+            }
+
+            const message = event.data;
+
+            // Find the matching subscriptions and call their handler
+            this.subscriptions.forEach((subscription, key) => {
+                // Check if message type matches
+                if (key !== message.name) {
                     return;
                 }
 
-                const message = event.data;
-
-                // Find the matching subscriptions and call their handler
-                this.subscriptions.forEach((subscription, key) => {
-                    // Check if message type matches
-                    if (key !== message.name) {
-                        return;
-                    }
-
-                    // Check if the event source matches any of the specified sources.
-                    // contentWindow is resolved lazily here — the iframe must be loaded
-                    // to have sent a message, so getContentWindow() is safe at this point.
-                    const sourceMatches = subscription.sources.some((source) => {
-                        try {
-                            return source.getContentWindow() === event.source;
-                        } catch (error) {
-                            this.logger.error('Failed to resolve contentWindow object for Iframe', error, { event });
-                            return false;
-                        }
-                    });
-                    if (!sourceMatches) {
-                        return;
-                    }
-
-                    // Call the handler
+                // Check if the event source matches any of the specified sources.
+                // contentWindow is resolved lazily here — the iframe must be loaded
+                // to have sent a message, so getContentWindow() is safe at this point.
+                const sourceMatches = subscription.sources.some((source) => {
                     try {
-                        subscription.handler(message);
+                        return source.getContentWindow() === event.source;
                     } catch (error) {
-                        this.logger.error('Error in message handler', error);
+                        this.logger.error('Failed to resolve contentWindow object for Iframe', error, { event });
+                        return false;
                     }
                 });
-            } catch (error) {
-                this.logger.error('Error processing iframe message', error);
-            }
-        });
+                if (!sourceMatches) {
+                    return;
+                }
+
+                // Call the handler
+                try {
+                    subscription.handler(message);
+                } catch (error) {
+                    this.logger.error('Error in message handler', error);
+                }
+            });
+        } catch (error) {
+            this.logger.error('Error processing iframe message', error);
+        }
     }
 }


### PR DESCRIPTION
## Reason, description, and testing instructions for the change

**Reason and description of the change**

Each `MontonioCheckout` / `Iframe` instance attached a `window` `'message'` listener that was never removed, so re-mounting the SDK (e.g. when the host page re-renders the mount element) accumulated listeners across the page lifetime. Stale listeners would call `getContentWindow()` on detached iframes and log `Failed to resolve contentWindow object for Iframe` on every incoming message.

- Added `MessagingService.destroy()` that clears subscriptions and removes the window message listener
- **Renamed `BaseComponent.cleanup()` → `destroy()`** to match the new naming and better convey that the instance is unusable afterward. `PaymentAuth` override and internal call sites updated accordingly
- `BaseComponent.destroy()` now also tears down its own `MessagingService` and resets `loaded = false`
- `Iframe.unmount()` now calls `messagingService.destroy()` instead of only clearing subscriptions, and no longer skips cleanup when `contentWindow` is unset
- Made `clearAllSubscriptions` private and removed unused `clearSubscriptionsExcept`

**Breaking-ish change:** external callers of `MontonioCheckout.cleanup()` must be updated to `.destroy()`. However, this method has not been documented publicly.

**Specific testing steps for this PR (if applicable):**

- Mount `MontonioCheckout`, then call `destroy()`, then mount a new instance — verify no `Failed to resolve contentWindow` errors in the console
- Verify the embedded card flow still completes end-to-end (mount → submit → 3DS → success)

_Refer to our [testing guidelines](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%F0%9F%A7%AA-Testing-your-changes) for general instructions on testing the change and verifying it doesn't introduce security issues._

## Rollback procedure
_Refer to our [rollback guide](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%99%BB%EF%B8%8F-Rolling-back-changes-(procedures-to-address-failures)) for rolling back the change in case of failure._

## Checklist

- [x] I have performed a self-review of my own code, tested the change manually, and verified the security impact.
- [x] I have followed Montonio's [Software Development and Release Process](https://montonio.atlassian.net/wiki/x/FYAU0w), [Secure Coding Guidelines](https://montonio.atlassian.net/wiki/x/GAAa0w), and [Configuration Standards](https://montonio.atlassian.net/wiki/x/BIAb0w).

**Security impact**
  - [ ] High
  - [ ] Medium
  - [x] Low

**Significant change**

Is this a Significant Change in the context of [our definition of a Significant Change](https://montonio.atlassian.net/wiki/spaces/ENG/pages/3541336085/#%E2%8F%AB-Significant-changes)?
- [ ] Yes
- [x] No